### PR TITLE
fix: prioritize _CONDOR_SCRATCH_DIR over SLURM_TMPDIR

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -72,10 +72,10 @@ echo "SLURM_ARRAY_JOB_ID=${SLURM_ARRAY_JOB_ID:-}"
 echo "SLURM_ARRAY_TASK_ID=${SLURM_ARRAY_TASK_ID:-}"
 echo "_CONDOR_SCRATCH_DIR=${_CONDOR_SCRATCH_DIR:-}"
 echo "OSG_WN_TMP=${OSG_WN_TMP:-}"
-if [ -n "${SLURM_TMPDIR:-}" ] ; then
-  TMPDIR=${SLURM_TMPDIR}
-elif [ -n "${_CONDOR_SCRATCH_DIR:-}" ] ; then
+if [ -n "${_CONDOR_SCRATCH_DIR:-}" ] ; then
   TMPDIR=${_CONDOR_SCRATCH_DIR}
+elif [ -n "${SLURM_TMPDIR:-}" ] ; then
+  TMPDIR=${SLURM_TMPDIR}
 else
   if [ -d "/scratch/slurm/${SLURM_JOB_ID:-}" ] ; then
     TMPDIR="/scratch/slurm/${SLURM_JOB_ID:-}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This should get jobs to pick up /srv on cedar.
