### PR TITLE
Default detector version should be main

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -37,7 +37,7 @@ test -f .machine.ad && cat .machine.ad
 
 # Load container environment (include ${DETECTOR_VERSION})
 export DETECTOR_CONFIG_REQUESTED=${DETECTOR_CONFIG:-}
-source /opt/detector/epic-${DETECTOR_VERSION:-nightly}/bin/thisepic.sh
+source /opt/detector/epic-${DETECTOR_VERSION:-main}/bin/thisepic.sh
 export DETECTOR_CONFIG=${DETECTOR_CONFIG_REQUESTED:-${DETECTOR_CONFIG:-$DETECTOR}}
 
 # Argument parsing


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Default detector version should be main. Otherwise it breaks production timing calculations
<img width="853" alt="Screenshot 2024-05-23 at 3 07 31 PM" src="https://github.com/eic/simulation_campaign_hepmc3/assets/7409132/1278b62e-5e92-49e4-bb41-d5cd5530cb07">


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
