### PR TITLE
Default to main when DETECTOR_VERSION is undefined

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -109,7 +109,7 @@ INPUT_PREFIX=${INPUT_DIR/\/*/}
 TAG=${INPUT_DIR/${INPUT_PREFIX}\//}
 INPUT_DIR=${BASEDIR}/EVGEN/${TAG}
 mkdir -p ${INPUT_DIR}
-TAG=${DETECTOR_VERSION}/${DETECTOR_CONFIG}/${TAG}
+TAG=${DETECTOR_VERSION:-main}/${DETECTOR_CONFIG}/${TAG}
 
 # Define location on xrootd from where to stream input file from
 INPUT_FILE=${XRDRURL}/${XRDRBASE}/${INPUT_FILE}


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Fixes another location where it should default to main when DETECTOR_VERSION is undefined

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
