### PR TITLE
fix: avoid prmon.log clobbering

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -169,6 +169,7 @@ mkdir -p ${RECO_TEMP}
   prmon \
     --filename ${LOG_TEMP}/${TASKNAME}.npsim.prmon.txt \
     --json-summary ${LOG_TEMP}/${TASKNAME}.npsim.prmon.json \
+    --log-filename ${LOG_TEMP}/${TASKNAME}.npsim.prmon.log \
     -- \
   npsim "${common_flags[@]}" "${uncommon_flags[@]}"
   ls -al ${FULL_TEMP}/${TASKNAME}.edm4hep.root  
@@ -189,6 +190,7 @@ fi
   prmon \
     --filename ${LOG_TEMP}/${TASKNAME}.eicrecon.prmon.txt \
     --json-summary ${LOG_TEMP}/${TASKNAME}.eicrecon.prmon.json \
+    --log-filename ${LOG_TEMP}/${TASKNAME}.eicrecon.prmon.log \
     -- \
   eicrecon \
     -Ppodio:output_file="${RECO_TEMP}/${TASKNAME}.eicrecon.tree.edm4eic.root" \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
By default prmon writes a log of its own to prmon.log. When multiple jobs run in the same directory, this results in clobbering. 