### PR TITLE
fix: allow empty XRD URL overrides for local read/write

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -65,13 +65,13 @@ fi
 # Output location
 BASEDIR=${DATADIR:-${PWD}}
 
-# XRD Write locations
-XRDWURL="xroots://dtn2201.jlab.org/"
+# XRD Write locations (allow for empty URL override)
+XRDWURL=${XRDWURL-"xroots://dtn2201.jlab.org/"}
 XRDWBASE=${XRDWBASE:-"/eic/eic2/EPIC"}
 
-# XRD Read locations
-XRDRURL="root://dtn-eic.jlab.org/"
-XRDRBASE="/work/eic2/EPIC"
+# XRD Read locations (allow for empty URL override)
+XRDRURL=${XRDRURL-"root://dtn-eic.jlab.org/"}
+XRDRBASE=${XRDRBASE:-"/work/eic2/EPIC"}
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"
@@ -178,7 +178,11 @@ mkdir -p ${RECO_TEMP}
 if [ "${COPYFULL:-false}" == "true" ] ; then
   # Token for write authentication
   export BEARER_TOKEN=$(cat ${_CONDOR_CREDS}/eic.use)
-  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${FULL_DIR} || echo "Cannot write simulation outputs to xrootd server" 
+  if [ -n ${XRDWURL} ] ; then
+    xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${FULL_DIR} || echo "Cannot write simulation outputs to xrootd server"
+  else
+    mkdir -p ${XRDWBASE}/${FULL_DIR} || echo "Cannot write simulation outputs to xrootd server"
+  fi
   xrdcp --force --recursive ${FULL_TEMP}/${TASKNAME}.edm4hep.root ${XRDWURL}/${XRDWBASE}/${FULL_DIR} 
 fi
 
@@ -206,13 +210,21 @@ ls -al ${LOG_TEMP}/${TASKNAME}.*
 if [ "${COPYRECO:-false}" == "true" ] ; then
   # Token for write authentication
   export BEARER_TOKEN=$(cat ${_CONDOR_CREDS}/eic.use)
-  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${RECO_DIR} || echo "Cannot write reconstructed outputs to xrootd server"
+  if [ -n ${XRDWURL} ] ; then
+    xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${RECO_DIR} || echo "Cannot write reconstructed outputs to xrootd server"
+  else
+    mkdir -p ${XRDWBASE}/${RECO_DIR} || echo "Cannot write reconstructed outputs to xrootd server"
+  fi
   xrdcp --force --recursive ${RECO_TEMP}/${TASKNAME}*.edm4eic.root ${XRDWURL}/${XRDWBASE}/${RECO_DIR} 
 fi
 if [ "${COPYLOG:-false}" == "true" ] ; then
   # Token for write authentication
   export BEARER_TOKEN=$(cat ${_CONDOR_CREDS}/eic.use)
-  xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${LOG_DIR} || echo "Cannot write log outputs to xrootd server"
+  if [ -n ${XRDWURL} ] ; then
+    xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${LOG_DIR} || echo "Cannot write log outputs to xrootd server"
+  else
+    mkdir -p ${XRDWBASE}/${LOG_DIR} || echo "Cannot write log outputs to xrootd server"
+  fi
   xrdcp --force --recursive ${LOG_TEMP}/${TASKNAME}.* ${XRDWURL}/${XRDWBASE}/${LOG_DIR}
 fi
 


### PR DESCRIPTION
### Briefly, what does this PR introduce?
This PR allow for overriding `XRDWURL` and `XRDRURL` with empty strings to assume local files (mostly for write this is relevant here). If undefined, the previous defaults are used; if defined as empty string, the previous defaults are not substituted.

There seems to be no way to make `xrdfs ${XRDWURL} mkdir -p ${XRDWBASE}/${RECO_DIR}` work on local filesystems or without an xrootd server running on localhost, so a bypass is needed there. I wish we could just use URLs with `file:///` in general but that prevents it.