### PR TITLE
Switch to ubuntu 22.04 and use eic_xl image instead of jug_xl

### DIFF
--- a/.github/workflows/run_prod.yml
+++ b/.github/workflows/run_prod.yml
@@ -24,7 +24,7 @@ jobs:
       env:
           X509_PROXY: ${{ secrets.X509_PROXY }} 
       with:
-        platform-release: "jug_xl:nightly"
+        platform-release: "eic_xl:nightly"
         run: |
           eic-info
           # Generate a timestamp

--- a/.github/workflows/run_prod.yml
+++ b/.github/workflows/run_prod.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   build-and-run:
     # Note: this workflow must run on linux 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - uses: cvmfs-contrib/github-action-cvmfs@v3


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Switch to ubuntu 22.04 and use eic_xl image instead of jug_xl

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
