### PR TITLE
Use energy config suffixed geometry for both npsim and eicrecon

### DIFF
--- a/.github/workflows/run_prod.yml
+++ b/.github/workflows/run_prod.yml
@@ -35,6 +35,8 @@ jobs:
           export X509_USER_PROXY=x509_user_proxy
           
           # Test running hepmc3 file
+          EBEAM=18 \
+          PBEAM=275 \
           DETECTOR_CONFIG="epic_craterlake" \
           DETECTOR_VERSION="main" \
           TAG_PREFIX="CI/${timestamp}" \
@@ -45,6 +47,8 @@ jobs:
           scripts/run.sh EVGEN/DIS/NC/18x275/minQ2=1/pythia8NCDIS_18x275_minQ2=1_beamEffects_xAngle=-0.025_hiDiv_1 hepmc3.tree.root 10
 
           # Test running singles file
+          EBEAM=5 \
+          PBEAM=41 \
           DETECTOR_CONFIG="epic_craterlake" \
           DETECTOR_VERSION="main" \
           TAG_PREFIX="CI/${timestamp}" \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -186,7 +186,7 @@ mkdir -p ${RECO_TEMP}
     --log-filename ${LOG_TEMP}/${TASKNAME}.eicrecon.prmon.log \
     -- \
   eicrecon \
-    -Pdd4hep:xml_files="${DETECTOR_PATH}/${DETECTOR_CONFIG}${EBEAM:+${PBEAM:+_${EBEAM}x${PBEAM}}}.xml"
+    -Pdd4hep:xml_files="${DETECTOR_PATH}/${DETECTOR_CONFIG}${EBEAM:+${PBEAM:+_${EBEAM}x${PBEAM}}}.xml" \
     -Ppodio:output_file="${RECO_TEMP}/${TASKNAME}.eicrecon.edm4eic.root" \
     -Pjana:warmup_timeout=0 -Pjana:timeout=0 \
     -Pplugins=janadot \

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -148,6 +148,7 @@ mkdir -p ${RECO_TEMP}
     --printLevel WARNING
     --filter.tracker 'edep0'
     --numberOfEvents ${EVENTS_PER_TASK}
+    --compactFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}${EBEAM:+${PBEAM:+_${EBEAM}x${PBEAM}}}.xml
     --outputFile ${FULL_TEMP}/${TASKNAME}.edm4hep.root
   )
   # Uncommon flags based on EXTENSION
@@ -156,7 +157,6 @@ mkdir -p ${RECO_TEMP}
       --runType batch
       --skipNEvents ${SKIP_N_EVENTS}
       --hepmc3.useHepMC3 ${USEHEPMC3:-true}
-      --compactFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}${EBEAM:+${PBEAM:+_${EBEAM}x${PBEAM}}}.xml
       --inputFiles ${INPUT_FILE}
     )
   else
@@ -164,7 +164,6 @@ mkdir -p ${RECO_TEMP}
       --runType run
       --enableGun
       --steeringFile ${INPUT_FILE}
-      --compactFile ${DETECTOR_PATH}/${DETECTOR_CONFIG}.xml
     )
   fi
   # Run npsim with both common and uncommon flags
@@ -187,6 +186,7 @@ mkdir -p ${RECO_TEMP}
     --log-filename ${LOG_TEMP}/${TASKNAME}.eicrecon.prmon.log \
     -- \
   eicrecon \
+    -Pdd4hep:xml_files="${DETECTOR_PATH}/${DETECTOR_CONFIG}${EBEAM:+${PBEAM:+_${EBEAM}x${PBEAM}}}.xml"
     -Ppodio:output_file="${RECO_TEMP}/${TASKNAME}.eicrecon.edm4eic.root" \
     -Pjana:warmup_timeout=0 -Pjana:timeout=0 \
     -Pplugins=janadot \


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Use subscripted geometry for both npsim and eicrecon. Some channels were reporting geometry related discrepancy in output which may have originated from defaulting to unsuffixed geometry in eicrecon. 

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
