### PR TITLE
fix: /work/eic2 -> /volatile/eic

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -73,7 +73,7 @@ XRDWBASE=${XRDWBASE:-"/eic/eic2/EPIC"}
 
 # XRD Read locations (allow for empty URL override)
 XRDRURL=${XRDRURL-"root://dtn-eic.jlab.org/"}
-XRDRBASE=${XRDRBASE:-"/work/eic2/EPIC"}
+XRDRBASE=${XRDRBASE:-"/volatile/eic/EPIC"}
 
 # Local temp dir
 echo "SLURM_TMPDIR=${SLURM_TMPDIR:-}"


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Replace /work/eic2 with /volatile/eic in executable code.
