### PR TITLE
Resetting of variables cannot be done in subshells. Move it outside.

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -180,11 +180,12 @@ if [[ "$EXTENSION" == "hepmc3.tree.root" ]]; then
       "${BG_ARGS[@]}" \
       --outputFile ${FULL_TEMP}/${TASKNAME}.hepmc3.tree.root
 
-    # Use background merged file as input for next stage
-    INPUT_FILE=${FULL_TEMP}/${TASKNAME}.hepmc3.tree.root
-    # Don't skip events on the background merged file
-    SKIP_N_EVENTS=0
   } 2>&1 | tee ${LOG_TEMP}/${TASKNAME}.hepmcmerger.log | tail -n1000
+
+  # Use background merged file as input for next stage
+  INPUT_FILE=${FULL_TEMP}/${TASKNAME}.hepmc3.tree.root
+  # Don't skip events on the background merged file
+  SKIP_N_EVENTS=0
 else
   echo "No background mixing is performed for singles"
 fi


### PR DESCRIPTION
### Briefly, what does this PR introduce?
Resetting of INPUT_FILE and SKIP_N_EVENTS variables cannot be done in subshells. Move it outside.


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
