### PR TITLE
The rucio account needs to be explicitly set.

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -43,6 +43,7 @@ export DETECTOR_VERSION=${DETECTOR_VERSION_REQUESTED}
 export DETECTOR_CONFIG=${DETECTOR_CONFIG_REQUESTED:-${DETECTOR_CONFIG:-$DETECTOR}}
 export SCRIPT_DIR=$(realpath $(dirname $0))
 export RUCIO_CONFIG=$SCRIPT_DIR/rucio.cfg
+export RUCIO_ACCOUNT=eicprod
 
 # Print out the location of the rucio config file
 echo $RUCIO_CONFIG


### PR DESCRIPTION
This is explicitly required when the script is running under PanDA which sets the rucio account variable. Since we use different rucio instances for logging and storing outputs, this needs to be reset when in the payload so as to not pickup the default PanDA variable.

### Briefly, what does this PR introduce?


### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Documentation update
- [ ] Other: __

### Please check if this PR fulfills the following:
- [ ] Tests for the changes have been added
- [ ] Documentation has been added / updated
- [ ] Changes have been communicated to collaborators

### Does this PR introduce breaking changes? What changes might users need to make to their code?

### Does this PR change default behavior?
