### PR TITLE
fix: uncomment and update set_metadata_bulk call in backfill script

### DIFF
--- a/scripts/backfill_metadata.py
+++ b/scripts/backfill_metadata.py
@@ -33,6 +33,10 @@ parser.add_argument(
     "-c", "--campaigns", nargs="+", required=True,
     help="List of campaign version strings (e.g. 26.03.0 26.03.1)"
 )
+parser.add_argument(
+    "--dry-run", action="store_true",
+    help="Print metadata that would be set without making any changes in Rucio"
+)
 args = parser.parse_args()
 
 # Build version_map from campaign args: X.Y.Z -> X.Y.Z-stable
@@ -240,9 +244,13 @@ for did in datasets_dids:
     metadata = {k: v for k, v in metadata.items() if v is not None}
 
     # now add the metadata to the dataset DID in Rucio
-    try:
-        client.set_metadata_bulk(scope="epic", name=did, meta=metadata, recursive=False)
-        print(f"Metadata added successfully for DID: {did}")
-    except Exception as e:
-        print(f"Error adding metadata for DID: {did}, error: {e}")
+    if args.dry_run:
+        print(f"[DRY RUN] Would set metadata for DID: {did}")
+        print(f"[DRY RUN] metadata: {metadata}")
+    else:
+        try:
+            client.set_metadata_bulk(scope="epic", name=did, meta=metadata, recursive=False)
+            print(f"Metadata added successfully for DID: {did}")
+        except Exception as e:
+            print(f"Error adding metadata for DID: {did}, error: {e}")
 

--- a/scripts/backfill_metadata.py
+++ b/scripts/backfill_metadata.py
@@ -240,9 +240,9 @@ for did in datasets_dids:
     metadata = {k: v for k, v in metadata.items() if v is not None}
 
     # now add the metadata to the dataset DID in Rucio
-    #try:
-    #    client.set_metadata_bulk(scope="epic", name=did, metadata=metadata)
-    #    print(f"Metadata added successfully for DID: {did}")
-    #except Exception as e:
-    #    print(f"Error adding metadata for DID: {did}, error: {e}")
+    try:
+        client.set_metadata_bulk(scope="epic", name=did, meta=metadata, recursive=False)
+        print(f"Metadata added successfully for DID: {did}")
+    except Exception as e:
+        print(f"Error adding metadata for DID: {did}, error: {e}")
 


### PR DESCRIPTION
### Briefly, what does this PR introduce? Please link to any relevant presentations or discussions.
Update the metadata upload block to use the correct parameter name (`meta` instead of `metadata`) and add `recursive=False` argument.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



### What is the urgency of this PR?
- [ ] High
- [ ] Medium
- [ ] Low

### What kind of change does this PR introduce?
- [ ] Bug fix (issue #__)
- [ ] New feature (issue #__)
- [ ] Optimization (issue #__)
- [ ] Updated documentation
- [ ] other: __

### Please check if any of the following apply
- [ ] This PR introduces breaking changes. Please describe changes users need to make below.
- [ ] This PR changes default behavior. Please describe changes below.
- [ ] AI was used in preparing this PR. Please describe usage below.
