### PR TITLE
fix: allow underscores in geometry_config detector name prefix

### DIFF
--- a/scripts/register_to_rucio.py
+++ b/scripts/register_to_rucio.py
@@ -95,7 +95,7 @@ METADATA_SCHEMA = {
         "geometry_config": {
             "type": "string",
             "description": "Geometry configuration tag (e.g. craterlake_18x275, craterlake_5x41_He3)",
-            "pattern": "^[a-z][a-z0-9]*_[0-9]+x[0-9]+(_.+)?$"
+            "pattern": "^[a-z][a-z0-9_]*_[0-9]+x[0-9]+(_.+)?$"
         },
         "gun_momentum_min_gev": {
             "type": "number",


### PR DESCRIPTION
The regex pattern for geometry_config was too restrictive, only allowing a single alphanumeric word before the NxM beam energy segment. This caused validation to reject valid configs like
'craterlake_without_zdc_5x41_Au197' which have underscores in the detector name.

Updated pattern from `^[a-z][a-z0-9]*_` to `^[a-z][a-z0-9_]*_` to permit underscores in the detector name portion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


