### PR TITLE
Fix software release pattern

### DIFF
--- a/scripts/register_to_rucio.py
+++ b/scripts/register_to_rucio.py
@@ -20,8 +20,8 @@ METADATA_SCHEMA = {
     "properties": {
         "software_release": {
             "type": "string",
-            "description": "Container version tag (e.g. 26.03.0-stable, nightly)",
-            "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly)$"
+            "description": "Container version tag (e.g. 26.03.0-stable, nightly, unstable)",
+            "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly|unstable)$"
         },
         "requester_pwg": {
             "type": "string",

--- a/scripts/register_to_rucio.py
+++ b/scripts/register_to_rucio.py
@@ -20,7 +20,7 @@ METADATA_SCHEMA = {
     "properties": {
         "software_release": {
             "type": "string",
-            "description": "Container version tag (e.g. 26.03.0-stable, nightly, unstable)",
+            "description": "Container version tag (e.g. 26.03.0-stable, nightly, unstable, or default)",
             "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly|unstable|default)$"
         },
         "requester_pwg": {

--- a/scripts/register_to_rucio.py
+++ b/scripts/register_to_rucio.py
@@ -21,7 +21,7 @@ METADATA_SCHEMA = {
         "software_release": {
             "type": "string",
             "description": "Container version tag (e.g. 26.03.0-stable, nightly, unstable)",
-            "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly|unstable)$"
+            "pattern": "^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly|unstable|default)$"
         },
         "requester_pwg": {
             "type": "string",

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -273,7 +273,7 @@ ls -al ${LOG_TEMP}/${TASKNAME}.*
 
 # Build metadata JSON string for Rucio registration
 # Extract software release from eic-info: strip trailing (-default)?-<40hexchars> in one pass
-JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )\S+' | head -1 | grep -oP '(\d+\.\d+\.\d+-stable|nightly|unstable|default)')
+JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )(\d+\.\d+\.\d+-(stable|unstable|nightly))')
 # Extract metadata from FULL file via podio (all fields except software_release)
 PODIO_ARGS=("${FULL_TEMP}/${TASKNAME}.edm4hep.root")
 if [[ "$EXTENSION" != "hepmc3.tree.root" ]]; then

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -273,7 +273,7 @@ ls -al ${LOG_TEMP}/${TASKNAME}.*
 
 # Build metadata JSON string for Rucio registration
 # Extract software release from eic-info: strip trailing (-default)?-<40hexchars> in one pass
-JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )(\d+\.\d+\.\d+-(stable|unstable|nightly))')
+JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )([\d.]+-(?=stable)|.*?\K)(stable|unstable|nightly|default)')
 # Extract metadata from FULL file via podio (all fields except software_release)
 PODIO_ARGS=("${FULL_TEMP}/${TASKNAME}.edm4hep.root")
 if [[ "$EXTENSION" != "hepmc3.tree.root" ]]; then


### PR DESCRIPTION
## Fix software release pattern


## Bug
```
Successfully uploaded file BeAGLE1.03.02-1.0_DIS_eCu_en_10x115_q2_1to1000_ab.0002.log.tar.gz
/opt/local/lib/python3.13/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'rucio-server.jlab.org'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(
Upload completed successfully!
Traceback (most recent call last):
  File "/opt/campaigns/hepmc3/scripts/register_to_rucio.py", line 194, in validate_metadata
    json_validate(instance=metadata, schema=METADATA_SCHEMA)
    ~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/local/lib/python3.13/site-packages/jsonschema/validators.py", line 1332, in validate
    raise error
jsonschema.exceptions.ValidationError: '26.04.1-stable\ndefault' does not match '^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly)$'

Failed validating 'pattern' in schema['properties']['software_release']:
    {'type': 'string',
     'description': 'Container version tag (e.g. 26.03.0-stable, nightly)',
     'pattern': '^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly)$'}

On instance['software_release']:
    '26.04.1-stable\ndefault'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/opt/campaigns/hepmc3/scripts/register_to_rucio.py", line 305, in <module>
    validate_metadata(dataset_meta)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/campaigns/hepmc3/scripts/register_to_rucio.py", line 196, in validate_metadata
    raise ValueError(f"Metadata validation failed: {e.message}")
ValueError: Metadata validation failed: '26.04.1-stable\ndefault' does not match '^([0-9]+\\.[0-9]+\\.[0-9]+-stable|nightly)$'
```


## Solution
Use new extraction pattern
```
[rahmans@ifarm2401 ~]$ /work/eic3/users/rahmans/container/nightly/eic-shell --version 26.04.1-stable
INFO:    Environment variable SINGULARITY_BINDPATH is set, but APPTAINER_BINDPATH is preferred
jug_dev+> rahmans@ifarm2401:~$ JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )([\d.]+-(?=stable)|.*?\K)(stable|unstable|nightly|default)')
jug_dev+> rahmans@ifarm2401:~$ echo $JUG_XL_TAG
26.04.1-stable
jug_dev+> rahmans@ifarm2401:~$ exit
exit
[rahmans@ifarm2401 ~]$ /work/eic3/users/rahmans/container/nightly/eic-shell --version nightly
INFO:    Environment variable SINGULARITY_BINDPATH is set, but APPTAINER_BINDPATH is preferred
jug_dev> rahmans@ifarm2401:~$ JUG_XL_TAG=$(eic-info 2>/dev/null | grep -oP '(?<=jug_dev: )([\d.]+-(?=stable)|.*?\K)(stable|unstable|nightly|default)')
jug_dev> rahmans@ifarm2401:~$ echo $JUG_XL_TAG
nightly

```
